### PR TITLE
Update ModbusTCP.h

### DIFF
--- a/src/ModbusTCP.h
+++ b/src/ModbusTCP.h
@@ -18,7 +18,7 @@ class WiFiServerESPWrapper : public WiFiServer {
   public:
     WiFiServerESPWrapper(uint16_t port) : WiFiServer(port) {}
     inline WiFiClient accept() {
-        return available();
+        return WiFiServer::accept();
     }
 };
 


### PR DESCRIPTION
When using NodeMCU and the latest libraries, a warning about a deprecated method is displayed during compilation.